### PR TITLE
Lb training query

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -168,8 +168,8 @@ class Training_Program(SafeDeleteModel):
 
     program_name = models.CharField(max_length=100)
     program_desc = models.CharField(max_length=200)
-    start_date = models.DateField('Starting Date')
-    end_date = models.DateField('Ending Date')
+    start_date = models.DateTimeField('Starting Date')
+    end_date = models.DateTimeField('Ending Date')
     max_attendees =  models.IntegerField()
     employee = models.ManyToManyField(Employee, through='Join_Training_Employee', related_name='training_programs')
 

--- a/api/views.py
+++ b/api/views.py
@@ -99,9 +99,7 @@ class TrainingProgramViewSet(viewsets.ModelViewSet):
 
     filter_backends = (filters.SearchFilter, )
     search_fields = ('program_name', 'start_date')
-
-    filter_fields=('start_date',)
-    now = datetime.now()
+    now = timezone.now()
 
     def get_queryset(self):
         """custom queryset for grabbing the training programs with a start_date parameter
@@ -110,6 +108,7 @@ class TrainingProgramViewSet(viewsets.ModelViewSet):
         queryset = Training_Program.objects.all()
         # set the query param on the left to 'completed'
         keyword = self.request.query_params.get('completed', None)
+        
         # this is saying you can either query or not
         if keyword is not None:
             # if 'false' or 'False' is on right side of query param do the following

--- a/api/views.py
+++ b/api/views.py
@@ -102,9 +102,6 @@ class TrainingProgramViewSet(viewsets.ModelViewSet):
     now = timezone.now()
 
     def get_queryset(self):
-        """custom queryset for grabbing the training programs with a start_date parameter
-        """
-
         queryset = Training_Program.objects.all()
         # set the query param on the left to 'completed'
         keyword = self.request.query_params.get('completed', None)

--- a/api/views.py
+++ b/api/views.py
@@ -24,6 +24,12 @@ from api.serializers import ProductTypeSerializer
 from api.serializers import TrainingProgramSerializer
 from api.serializers import DepartmentSerializer
 
+from django.utils import timezone
+from datetime import datetime, date
+
+
+
+
 
 @api_view(['GET'])
 def api_root(request, format=None):
@@ -90,7 +96,32 @@ class OrderViewSet(viewsets.ModelViewSet):
 class TrainingProgramViewSet(viewsets.ModelViewSet):
     queryset = Training_Program.objects.all()
     serializer_class = TrainingProgramSerializer
-    
+
+    filter_backends = (filters.SearchFilter, )
+    search_fields = ('program_name', 'start_date')
+
+    filter_fields=('start_date',)
+    now = datetime.now()
+
+    def get_queryset(self):
+        """custom queryset for grabbing the training programs with a start_date parameter
+        """
+
+        queryset = Training_Program.objects.all()
+        # set the query param on the left to 'completed'
+        keyword = self.request.query_params.get('completed', None)
+        # this is saying you can either query or not
+        if keyword is not None:
+            # if 'false' or 'False' is on right side of query param do the following
+            if keyword == "false" or keyword == "False":
+                # filter the queryset so that start_date is >= today
+                queryset = Training_Program.objects.filter(start_date__gte=self.now)
+            # now looking for true on the right side of query
+            elif keyword == "true" or keyword == "True":
+                # filter to trainings with a start date in the past
+                queryset = Training_Program.objects.filter(end_date__lte=self.now)
+        return queryset
+
 class ComputerViewSet(viewsets.ModelViewSet):
     queryset = Computer.objects.all()
     serializer_class = ComputerSerializer


### PR DESCRIPTION
## Link to Ticket
#9 

## Description of Proposed Changes
-Added queryset method override for getting the completed training programs based on start date

## Steps to Test
This involved a model update to the datatimefield on start date and end date in training programs.  A new migration will be required.  After new migration, runserver, add a training program in the past and another in the future.  Make sure to add a new training program from the api browser and include time.  Then modify the URL in the browser to say http://localhost:8000/api/v1/training_programs/?completed=False

you should see the future training dates.

```shell
git fetch --all
git checkout lb-training-query
```

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Views
* Models


## Mentions @username
@robbyhecht
@BryanNilsen
@ousamasama 
