### PR TITLE
OE-Employee-Additions

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -71,7 +71,11 @@ class ComputerSerializer(serializers.HyperlinkedModelSerializer):
 class EmployeeSerializer(serializers.HyperlinkedModelSerializer):
     """translates employees to json"""
 
-    department = DepartmentSerializer(read_only=True)
+    # department = DepartmentSerializer(read_only=True)
+    department = serializers.SlugRelatedField(
+        read_only=True,
+        slug_field='department_name'
+     )
     computers = ComputerSerializer(many=True, read_only=True)
     class Meta:
         model = Employee

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -16,14 +16,6 @@ class CustomerSerializer(serializers.HyperlinkedModelSerializer):
         model = Customer
         fields = ('url', 'first_name', 'last_name', 'username', 'email', 'address', 'phone_number')
 
-
-class EmployeeSerializer(serializers.HyperlinkedModelSerializer):
-    """translates employees to json"""
-
-    class Meta:
-        model = Employee
-        fields = ('url', 'first_name', 'last_name', 'start_date', 'end_date', 'department', 'is_supervisor')
-
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """translates orders to json"""
 
@@ -61,12 +53,6 @@ class TrainingProgramSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Training_Program
         fields = ('id','program_name', 'program_desc', 'start_date', 'end_date', 'max_attendees','employee','url')
-class ComputerSerializer(serializers.HyperlinkedModelSerializer):
-    """translates computers to json"""
-
-    class Meta:
-        model = Computer
-        fields = ('purchase_date', 'decommission_date', 'manufacturer', 'model', 'is_available', 'employee', 'url')
 
 class DepartmentSerializer(serializers.HyperlinkedModelSerializer):
     """translates departments to json"""
@@ -75,10 +61,17 @@ class DepartmentSerializer(serializers.HyperlinkedModelSerializer):
         model = Department
         fields = ('url', 'department_name', 'budget')
 
+class ComputerSerializer(serializers.HyperlinkedModelSerializer):
+    """translates computers to json"""
+
+    class Meta:
+        model = Computer
+        fields = ('purchase_date', 'decommission_date', 'manufacturer', 'model', 'is_available', 'url')
 
 class EmployeeSerializer(serializers.HyperlinkedModelSerializer):
     """translates employees to json"""
 
+    department = DepartmentSerializer(read_only=True)
     class Meta:
         model = Employee
         fields = ('url', 'first_name', 'last_name', 'start_date', 'end_date', 'department', 'is_supervisor')

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -66,12 +66,13 @@ class ComputerSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Computer
-        fields = ('purchase_date', 'decommission_date', 'manufacturer', 'model', 'is_available', 'url')
+        fields = ('purchase_date', 'decommission_date', 'manufacturer', 'model', 'employee', 'is_available', 'url')
 
 class EmployeeSerializer(serializers.HyperlinkedModelSerializer):
     """translates employees to json"""
 
     department = DepartmentSerializer(read_only=True)
+    computers = ComputerSerializer(many=True, read_only=True)
     class Meta:
         model = Employee
-        fields = ('url', 'first_name', 'last_name', 'start_date', 'end_date', 'department', 'is_supervisor')
+        fields = ('url', 'first_name', 'last_name', 'start_date', 'end_date', 'department', 'computers', 'is_supervisor')

--- a/api/urls.py
+++ b/api/urls.py
@@ -14,7 +14,6 @@ router.register('orders', views.OrderViewSet)
 router.register('training_programs', views.TrainingProgramViewSet)
 router.register('departments', views.DepartmentViewSet)
 
-
 urlpatterns = [
     path('api/v1/', include(router.urls))
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -24,7 +24,6 @@ from api.serializers import ProductTypeSerializer
 from api.serializers import TrainingProgramSerializer
 from api.serializers import DepartmentSerializer
 
-
 @api_view(['GET'])
 def api_root(request, format=None):
     return Response({


### PR DESCRIPTION
## Link to Ticket
[Issue #6 ](https://github.com/talkative-tangs/Bangazon-API/issues/6)

## Description of Proposed Changes
Completed the issue started by Bryan by adding the additional logic to the serializer.

-On the API, you can now see the department name and the assigned computer under the related employee.
-Deleted the extra Employee serializer at the TOP of the serializer file.

## Steps to Test

After migrating your databases, check to ensure correctness and validity.

```sh
git fetch --all
git checkout oe-employee-additions

```

## Impacted Areas in Application

List general components of the application that this PR will affect:

* Serializers

## Mentions @username

@robbyhecht  
@BryanNilsen
@laboyd001