### PR TITLE
OE-Departments

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -80,6 +80,15 @@ class TrainingProgramSerializer(serializers.HyperlinkedModelSerializer):
 class DepartmentSerializer(serializers.HyperlinkedModelSerializer):
     """translates departments to json"""
 
+    def __init__(self, *args, **kwargs):
+        super(DepartmentSerializer, self).__init__(*args, **kwargs)
+        request = kwargs['context']['request']
+        include = request.query_params.get('_include')
+
+        if include:
+            if 'employees' in include:
+                self.fields['employees'] = EmployeeSerializer(many=True, read_only=True)
+
     class Meta:
         model = Department
         fields = ('url', 'department_name', 'budget')

--- a/api/views.py
+++ b/api/views.py
@@ -171,9 +171,11 @@ class DepartmentViewSet(viewsets.ModelViewSet):
 
         keyword = self.request.query_params.get('_filter')
         if keyword == 'budget':
+            keyword = keyword.lower()
 
             keyword = self.request.query_params.get('_gt')
             if keyword is not None:
+                keyword = keyword.lower()
                 query_set = query_set.filter(budget__gte=keyword)
 
         return query_set

--- a/api/views.py
+++ b/api/views.py
@@ -166,6 +166,18 @@ class DepartmentViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.SearchFilter, )
     search_fields = ('department_name', 'budget')
 
+    def get_queryset(self):
+        query_set = Department.objects.all()
+
+        keyword = self.request.query_params.get('_filter')
+        if keyword == 'budget':
+
+            keyword = self.request.query_params.get('_gt')
+            if keyword is not None:
+                query_set = query_set.filter(budget__gte=keyword)
+
+        return query_set
+
     # use method for includes, will adjust settings/filter above for q
     # issue 1, elif
     # def get_queryset(self):


### PR DESCRIPTION
## Link to Ticket
[Issue #7](https://github.com/talkative-tangs/Bangazon-API/issues/7)

## Description of Proposed Changes

-Afforded the API's user the opportunity to filter departments by budget(greater than or equal to the query), and query the departments to see if they house any employees.

## Steps to Test

-If the query string parameter of ```?_include=employees``` is provided, then all employees in the department(s) should be included in the response.
-If the query string parameters of ```?_filter=budget&_gt=300000``` is provided on a request for the list of departments, then any department whose budget is $300,000, or greater, should be in the response.

```sh
git fetch --all
git checkout oe-departments

```

## Impacted Areas in Application

List general components of the application that this PR will affect:

* Serializers
* Views

## Mentions @username

@robbyhecht  
@BryanNilsen
@laboyd001